### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/mattbostock/leavediary.png?label=ready&title=Ready)](https://waffle.io/mattbostock/leavediary)
 [![Build Status](https://travis-ci.org/mattbostock/leavediary.svg?branch=master)](https://travis-ci.org/mattbostock/leavediary)
 [![Go Report Card](http://goreportcard.com/badge/mattbostock/leavediary)](http://goreportcard.com/report/mattbostock/leavediary)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/mattbostock/leavediary

This was requested by a real person (user mattbostock) on waffle.io, we're not trying to spam you.
