### PR TITLE
Define leave as all day events when exporting ICS

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -72,7 +72,7 @@
 		},
 		{
 			"ImportPath": "github.com/soh335/ical",
-			"Rev": "9e3fbc2c77081d0ef018279ab30b00c89d417ece"
+			"Rev": "50e48f3ed299fb2a2b9e232f87684ac22153a139"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",

--- a/Godeps/_workspace/src/github.com/soh335/ical/ical.go
+++ b/Godeps/_workspace/src/github.com/soh335/ical/ical.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	stampLayout = "20060102T150405Z"
-	dateLayout  = "20060102T150405"
+	stampLayout    = "20060102T150405Z"
+	dateLayout     = "20060102"
+	dateTimeLayout = "20060102T150405"
 )
 
 type VCalendar struct {
@@ -81,9 +82,21 @@ type VEvent struct {
 	DTEND   time.Time
 	SUMMARY string
 	TZID    string
+
+	AllDay bool
 }
 
 func (e *VEvent) EncodeIcal(w io.Writer) error {
+
+	var timeStampLayout, timeStampType string
+
+	if e.AllDay {
+		timeStampLayout = dateLayout
+		timeStampType = "DATE"
+	} else {
+		timeStampLayout = dateTimeLayout
+		timeStampType = "DATE-TIME"
+	}
 
 	b := bufio.NewWriter(w)
 	if _, err := b.WriteString("BEGIN:VEVENT\r\n"); err != nil {
@@ -101,10 +114,10 @@ func (e *VEvent) EncodeIcal(w io.Writer) error {
 	if _, err := b.WriteString("SUMMARY:" + e.SUMMARY + "\r\n"); err != nil {
 		return err
 	}
-	if _, err := b.WriteString("DTSTART;TZID=" + e.TZID + ":" + e.DTSTART.Format(dateLayout) + "\r\n"); err != nil {
+	if _, err := b.WriteString("DTSTART;TZID=" + e.TZID + ";VALUE=" + timeStampType + ":" + e.DTSTART.Format(timeStampLayout) + "\r\n"); err != nil {
 		return err
 	}
-	if _, err := b.WriteString("DTEND;TZID=" + e.TZID + ":" + e.DTEND.Format(dateLayout) + "\r\n"); err != nil {
+	if _, err := b.WriteString("DTEND;TZID=" + e.TZID + ";VALUE=" + timeStampType + ":" + e.DTEND.Format(timeStampLayout) + "\r\n"); err != nil {
 		return err
 	}
 	if _, err := b.WriteString("END:VEVENT\r\n"); err != nil {

--- a/Godeps/_workspace/src/github.com/soh335/ical/ical_test.go
+++ b/Godeps/_workspace/src/github.com/soh335/ical/ical_test.go
@@ -7,17 +7,28 @@ import (
 	"time"
 )
 
-func Test_Encode(t *testing.T) {
+func testSetup(vComponents []VComponent) (bytes.Buffer, error) {
 	c := NewBasicVCalendar()
 	c.PRODID = "proid"
 	c.X_WR_TIMEZONE = "Asia/Tokyo"
 	c.X_WR_CALNAME = "name"
 	c.X_WR_CALDESC = "desc"
 
+	c.VComponent = vComponents
+
+	var b bytes.Buffer
+	if err := c.Encode(&b); err != nil {
+		return b, err
+	}
+
+	return b, nil
+}
+
+func testEncode(t *testing.T) {
 	zone := time.FixedZone("Asia/Tokyo", 60*60*9)
 	d := time.Date(2014, time.Month(1), 1, 0, 0, 0, 0, zone)
 
-	c.VComponent = []VComponent{
+	vComponents := []VComponent{
 		&VEvent{
 			UID:     "123",
 			DTSTAMP: d,
@@ -28,8 +39,8 @@ func Test_Encode(t *testing.T) {
 		},
 	}
 
-	var b bytes.Buffer
-	if err := c.Encode(&b); err != nil {
+	b, err := testSetup(vComponents)
+	if err != nil {
 		t.Error("got err:", err)
 	}
 
@@ -45,14 +56,64 @@ DTSTAMP:20131231T150000Z
 UID:123
 TZID:Asia/Tokyo
 SUMMARY:summary
-DTSTART;TZID=Asia/Tokyo:20140101T000000
-DTEND;TZID=Asia/Tokyo:20140101T000000
+DTSTART;TZID=Asia/Tokyo;VALUE=DATE-TIME:20140101T000000
+DTEND;TZID=Asia/Tokyo;VALUE=DATE-TIME:20140101T000000
 END:VEVENT
 END:VCALENDAR
 `
-	expect = strings.Replace(expect, "\n", "\r\n", -1)
+	expect = unixToDOSLineEndings(expect)
 
 	if s := b.String(); s != expect {
 		t.Errorf("should %v. but got %v", expect, s)
 	}
+}
+
+func testEncodeAllDay(t *testing.T) {
+	zone := time.FixedZone("Asia/Tokyo", 60*60*9)
+	d := time.Date(2014, time.Month(1), 1, 0, 0, 0, 0, zone)
+
+	vComponents := []VComponent{
+		&VEvent{
+			UID:     "123",
+			DTSTAMP: d,
+			DTSTART: d,
+			DTEND:   d,
+			SUMMARY: "summary",
+			TZID:    "Asia/Tokyo",
+
+			AllDay: true,
+		},
+	}
+
+	b, err := testSetup(vComponents)
+	if err != nil {
+		t.Error("got err:", err)
+	}
+
+	expect := `BEGIN:VCALENDAR
+PRODID:proid
+CALSCALE:GREGORIAN
+VERSION:2.0
+X-WR-CALNAME:name
+X-WR-CALDESC:desc
+X-WR-TIMEZONE:Asia/Tokyo
+BEGIN:VEVENT
+DTSTAMP:20131231T150000Z
+UID:123
+TZID:Asia/Tokyo
+SUMMARY:summary
+DTSTART;TZID=Asia/Tokyo;VALUE=DATE:20140101
+DTEND;TZID=Asia/Tokyo;VALUE=DATE:20140101
+END:VEVENT
+END:VCALENDAR
+`
+	expect = unixToDOSLineEndings(expect)
+
+	if s := b.String(); s != expect {
+		t.Errorf("should %v. but got %v", expect, s)
+	}
+}
+
+func unixToDOSLineEndings(input string) string {
+	return strings.Replace(input, "\n", "\r\n", -1)
 }

--- a/handler/export_ics.go
+++ b/handler/export_ics.go
@@ -48,6 +48,8 @@ func ExportICS(w http.ResponseWriter, r *http.Request) {
 			DTEND:   e.EndTime,
 			SUMMARY: user.Name + " annual leave: " + e.Description,
 			TZID:    e.StartTime.Location().String(),
+
+			AllDay: true, // FIXME Once part-day leave is supported
 		}
 		cal.VComponent = append(cal.VComponent, v)
 	}


### PR DESCRIPTION
When exporting ICS vCalendar files, define leave requests as all-day
events.

Currently, only all-day leave requests is supported. This change ensures
that calendar clients (i.e. Apple Calendar, Google Calendar) interpret
the exported events as all-day events.

Fixes #20.
