### PR TITLE
Prevent leave request from displaying twice

### DIFF
--- a/handler/dashboard.go
+++ b/handler/dashboard.go
@@ -56,7 +56,7 @@ func Dashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	for _, req := range requests {
-		if req.After(time.Now().AddDate(0, 0, -1).In(user.TZLocation())) {
+		if req.After(time.Now().In(user.TZLocation())) {
 			upcomingRequests = append(upcomingRequests, req)
 		}
 	}


### PR DESCRIPTION
If a leave request's start time is on the same day as the day a user
views the dashboard, that leave request will show both in 'Past time
off' section and the 'Upcoming' section.

This commit fixes that, so that a leave request starting on today's date
(at 00:00, since we only support full-day leave requests thus far) will
show in the 'Past time off' section.

Fixes #26.
