### PR TITLE
Allow user to set their name on /settings page

### DIFF
--- a/handler/settings.go
+++ b/handler/settings.go
@@ -22,8 +22,10 @@ func Settings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	job := user.CurrentJob()
+	formValues = make(url.Values)
+	formValues.Add("name", user.Name)
+
 	if job.ID > 0 {
-		formValues = make(url.Values)
 		formValues.Add("employer_name", job.EmployerName)
 		formValues.Add("job_start_year", job.StartTime.Format("2006"))
 		formValues.Add("job_start_month", job.StartTime.Format("1"))
@@ -33,6 +35,7 @@ func Settings(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
 		formValues = r.PostForm
 
+		name := r.PostFormValue("name")
 		employerName := r.PostFormValue("employer_name")
 		jobStart, err := time.ParseInLocation("2006-1-2",
 			fmt.Sprintf("%s-%s-%s",
@@ -47,6 +50,7 @@ func Settings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		user.Name = name
 		job.EmployerName = employerName
 		job.StartTime = jobStart
 
@@ -104,11 +108,12 @@ func Settings(w http.ResponseWriter, r *http.Request) {
 			})
 
 			user.Jobs = append(user.Jobs, job)
-			if err = user.Save(); err != nil {
-				internalError(w, err)
-				return
-			}
 
+		}
+
+		if err = user.Save(); err != nil {
+			internalError(w, err)
+			return
 		}
 
 		http.Redirect(w, r, "/dashboard", http.StatusSeeOther)

--- a/templates/settings.tmpl
+++ b/templates/settings.tmpl
@@ -5,6 +5,13 @@
 
     <div class="row">
     <div class="large-4 columns">
+      <label for="name">Your name</label>
+      <input type="text" name="name" value="{{ urlValue .FormValues "name" }}" required>
+    </div>
+    </div>
+
+    <div class="row">
+    <div class="large-4 columns">
       <label for="employer_name">What is the name of your employer?</label>
       <input type="text" name="employer_name" value="{{ urlValue .FormValues "employer_name" }}" required>
     </div>


### PR DESCRIPTION
Currently we pull the user's name from their GitHub profile, but not all
users will use their real name.

Allow them to set their real name, which is useful since we include it
in the exported ICS files and so would display in a calendaring
application.
