### PR TITLE
Add custom recovery middleware for Negroni to hide panics from user

### DIFF
--- a/handler/helpers.go
+++ b/handler/helpers.go
@@ -19,7 +19,7 @@ func internalError(w http.ResponseWriter, err error) {
 		})
 }
 
-func showError(w http.ResponseWriter, statusCode int, msg string) {
+func ShowError(w http.ResponseWriter, statusCode int, msg string) {
 	output.HTML(w, statusCode, "error",
 		&struct {
 			Msg  string

--- a/handler/settings.go
+++ b/handler/settings.go
@@ -82,7 +82,7 @@ func Settings(w http.ResponseWriter, r *http.Request) {
 
 			userNow := time.Now().In(user.TZLocation())
 			if userNow.After(leaveYearEnd) || userNow.Before(leaveYearStart) {
-				showError(w, http.StatusNotAcceptable, "Current leave year must not end before or start after today's date.")
+				ShowError(w, http.StatusNotAcceptable, "Current leave year must not end before or start after today's date.")
 				return
 			}
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/securecookie"
 	"github.com/mattbostock/leavediary/handler"
 	"github.com/mattbostock/leavediary/middleware/negroni_logrus"
+	"github.com/mattbostock/leavediary/middleware/recovery"
 	"github.com/mattbostock/leavediary/middleware/sessions"
 	"github.com/mattbostock/leavediary/model"
 	"github.com/unrolled/secure"
@@ -149,7 +150,7 @@ func main() {
 
 	n := negroni.New()
 	n.Use(negroniLogrus.New(log)) // logger must be first middleware
-	n.Use(negroni.NewRecovery())
+	n.Use(recovery.New(log))
 	n.Use(negroni.HandlerFunc(secureMiddleware.HandlerFuncWithNext))
 	n.Use(negroni.NewStatic(http.Dir(assetsPath)))
 	n.UseHandler(sessionManager)

--- a/middleware/recovery/recovery.go
+++ b/middleware/recovery/recovery.go
@@ -1,0 +1,39 @@
+package recovery
+
+import (
+	"net/http"
+	"runtime"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/mattbostock/leavediary/handler"
+)
+
+type middleware struct {
+	logger    *logrus.Logger
+	stackAll  bool
+	stackSize int
+}
+
+// New returns a new instance of middleware
+func New(log *logrus.Logger) *middleware {
+	return &middleware{
+		logger:    log,
+		stackAll:  false,
+		stackSize: 1024 * 8,
+	}
+}
+
+func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer func() {
+		if err := recover(); err != nil {
+			handler.ShowError(w, http.StatusInternalServerError, "")
+			stack := make([]byte, m.stackSize)
+			stack = stack[:runtime.Stack(stack, m.stackAll)]
+
+			f := "PANIC: %s\n%s"
+			m.logger.Errorf(f, err, stack)
+		}
+	}()
+
+	next(w, r)
+}


### PR DESCRIPTION
Create a new, custom, recovery middleware for Negroni so that:
- we can present a pretty error page to the user if the application
  panics
- we can output the stack trace using Logrus' logger for consistency
  with the rest of the application

I'm a little concerned that my making this recovery code more complex
(by rendering a pretty error page), we're increasing the risk of
panicking while recovering from the original panic.

This might be a good argument for dealing with this higher up the stack
(i.e. by configuring Nginx to output a pretty page when a HTTP 5XX
occurs), but for now I'm not using Nginx so this will do.

Fixes #16.
