### PR TITLE
Add one day to all-day events when exporting ICS

### DIFF
--- a/handler/export_ics.go
+++ b/handler/export_ics.go
@@ -41,11 +41,22 @@ func ExportICS(w http.ResponseWriter, r *http.Request) {
 	cal.X_WR_CALNAME = fmt.Sprintf("Time off for %s", user.Name)
 
 	for _, e := range requests {
+		endTime := e.EndTime
+
+		// Add a day if end time is midnight
+		// so that calendering applications will include last
+		// day of holiday when rendering all-day events
+		//
+		// FIXME: Revisit this when adding support for part-day leave
+		if e.EndTime.Format("15:04:00") == "00:00:00" {
+			endTime = e.EndTime.AddDate(0, 0, 1)
+		}
+
 		v := &ical.VEvent{
 			UID:     "LeaveDiary-" + strconv.FormatUint(e.ID, 10),
 			DTSTAMP: e.UpdatedAt,
 			DTSTART: e.StartTime,
-			DTEND:   e.EndTime,
+			DTEND:   endTime,
 			SUMMARY: user.Name + " annual leave: " + e.Description,
 			TZID:    e.StartTime.Location().String(),
 


### PR DESCRIPTION
When exporting ICS vCalendar files, add one day to the event end time so
that calendaring applications include the last day of holiday when
rendering all-day events.

This will need to be revisited when support for part-day leave is added.
